### PR TITLE
fix: docker cmd not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /drone/src
 
 COPY plugin /drone/src
 
-CMD ["node","plugin/index.js"]
+CMD ["node","index.js"]


### PR DESCRIPTION
When use new docker image, but get `index.js` not found
![](https://user-images.githubusercontent.com/1111538/89914291-6126f600-dc27-11ea-8e33-22e302e0de9e.jpeg)
